### PR TITLE
防止手机自动休眠与亮度降到最低

### DIFF
--- a/app/src/main/java/cn/starrah/bluetoothvibrator2/MainActivity.kt
+++ b/app/src/main/java/cn/starrah/bluetoothvibrator2/MainActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.media.session.MediaSession
 import android.net.wifi.WifiManager
 import android.os.Build
@@ -12,6 +13,8 @@ import android.os.VibrationEffect
 import android.os.Vibrator
 import android.support.v7.app.AlertDialog
 import android.view.KeyEvent
+import android.view.Window
+import android.view.WindowManager
 import android.widget.ArrayAdapter
 import android.widget.EditText
 import kotlinx.android.synthetic.main.activity_main.*
@@ -29,7 +32,7 @@ class MainActivity : AppCompatActivity() {
         @JvmStatic
         val hosts: MutableList<String> = ArrayList()
     }
-
+    var urll = ""
     val duration: Int
         get() = Integer.parseInt(txtDur.text.toString())
     private val localIP: String
@@ -54,6 +57,7 @@ class MainActivity : AppCompatActivity() {
         override fun run() {
             while (true) {
                 sleep(500)
+                ac.urll = ac.txtDur4.text.toString()
                 if (ac.switch2.isChecked) {
                     val url = URL(ac.txtDur4.text.toString());
                     val urlConnection = url.openConnection() as HttpURLConnection
@@ -77,17 +81,35 @@ class MainActivity : AppCompatActivity() {
         }
 
     }
+
+    fun changeAppBrightness(brightness : Int) {
+        val window = this.getWindow();
+        val lp = window.getAttributes();
+        if (brightness == -1) {
+            lp.screenBrightness = WindowManager.LayoutParams.BRIGHTNESS_OVERRIDE_NONE;
+        } else {
+            lp.screenBrightness = (brightness) / 255f;
+        }
+        window.setAttributes(lp);
+    }
+
     val th = SendRequsetThread(this)
     override fun onCreate(savedInstanceState: Bundle?) {
 
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+        getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
         //Start serve
         //Add server hosts
         //Set local IP
         //Initialize ArrayAdapter
         //Set fab click
         th.start()
+        changeAppBrightness(0)
+        //val intentfilter = IntentFilter()
+        //intentfilter.addAction("android.media.VOLUME_CHANGED_ACTION")
+        //val volumeReceiver = VolumeReceiver(this)
+        //registerReceiver(volumeReceiver, intentfilter)
 
 
         //Register media button event

--- a/app/src/main/java/cn/starrah/bluetoothvibrator2/VolumeReceiver.java
+++ b/app/src/main/java/cn/starrah/bluetoothvibrator2/VolumeReceiver.java
@@ -1,0 +1,43 @@
+package cn.starrah.bluetoothvibrator2;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+
+public class VolumeReceiver extends BroadcastReceiver {
+
+        public MainActivity strUrl;
+        public VolumeReceiver(MainActivity strUrl) {
+            this.strUrl = strUrl;
+        }
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            System.out.println("receive");
+            if (intent.getAction().equals("android.media.VOLUME_CHANGED_ACTION")) {
+                new Thread() {
+                    public void run() {
+                        System.out.println("sendRequest");
+                        URL url = null;
+                        try {
+                            url = new URL(strUrl.getUrll());
+                            URLConnection urlConnection = url.openConnection();
+                            BufferedInputStream bufferedInputStream = new BufferedInputStream(urlConnection.getInputStream());
+                        } catch (MalformedURLException e) {
+                            e.printStackTrace();
+                        } catch (IOException e) {
+                            e.printStackTrace();
+                        }
+                    }
+                }.start();
+
+        }
+    }
+}


### PR DESCRIPTION
防止手机自动休眠以保持应用前台运行从而获取到事件；亮度降到最低，因为始终是前台运行，为了省电；这两个功能已确认可用。
另有失败的“广播接收器”方法尝试了一下，但是因为不明原因失败了，接收不到对应广播。出于备用考虑仍把相关接收器类留下，只是不注册即可。